### PR TITLE
Add external access option and doc updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 
 # ===== Core Configuration =====
 DOMAIN=yourdomain.com
+# Set to "local" to skip remote access and Cloudflare configuration
 ACCESS_MODE=remote
 COMPOSE_PROJECT_NAME=media-stack
 TZ=America/New_York

--- a/COMPLETE_NEWBIE_GUIDE.md
+++ b/COMPLETE_NEWBIE_GUIDE.md
@@ -18,8 +18,8 @@ By the end of this guide, you'll have:
 
 ### What You Need
 1. **A Computer/Server** running Linux, Windows, or macOS
-2. **A Domain Name** (e.g., `media.example.com`) - $10-15/year
-3. **Cloudflare Account** (free) - for SSL certificates
+2. **A Domain Name** (e.g., `media.example.com`) - $10-15/year *(only for external access)*
+3. **Cloudflare Account** (free) - for SSL certificates *(only for external access)*
 4. **Basic Storage** - External drive or NAS for your media
 5. **Internet Connection** - For downloading content and remote access
 
@@ -90,7 +90,7 @@ docker run hello-world
 
 You should see: `Hello from Docker!`
 
-## 🌐 Step 2: Domain and DNS Setup
+## 🌐 Step 2: Domain and DNS Setup *(skip if using local-only access)*
 
 ### Get a Domain Name
 1. Go to [Namecheap](https://namecheap.com) or [Cloudflare](https://cloudflare.com)

--- a/MEDIA_STACK_SETUP.md
+++ b/MEDIA_STACK_SETUP.md
@@ -28,8 +28,8 @@ This Docker Compose setup provides a complete media server stack with Jellyfin a
 ## Prerequisites
 
 1. **Docker and Docker Compose** installed
-2. **Cloudflare account** with domain managed by Cloudflare
-3. **Cloudflare API token** with Zone:Read and Zone:Zone permissions
+2. **Cloudflare account** with domain managed by Cloudflare *(only for external access)*
+3. **Cloudflare API token** with Zone:Read and Zone:Zone permissions *(only for external access)*
 4. **Directory structure** for media storage
 
 ## Setup Instructions

--- a/QUICK_START_CARD.md
+++ b/QUICK_START_CARD.md
@@ -6,9 +6,9 @@ _Last updated: July 2025_
 
 ## ✅ Pre-Setup Checklist
 
-- [ ] **Domain purchased** (e.g., `media.yourname.com`)
-- [ ] **Cloudflare account** created and domain added
-- [ ] **Cloudflare API token** obtained
+- [ ] **Domain purchased** (e.g., `media.yourname.com`) *(only for external access)*
+- [ ] **Cloudflare account** created and domain added *(only for external access)*
+- [ ] **Cloudflare API token** obtained *(only for external access)*
 - [ ] **Docker installed** and tested (`docker run hello-world`)
 - [ ] **Storage prepared** (external drive recommended)
 - [ ] **Router access** (for port forwarding)
@@ -91,13 +91,13 @@ Replace `yourdomain.com` with your actual domain:
 
 1. **Install Docker** → Test with `docker run hello-world`
 2. **Decide Access Mode** → Local only or Cloudflare remote (first setup prompt)
-3. **Get Domain** → Buy and add to Cloudflare
-4. **Get API Token** → From Cloudflare dashboard
+3. **Get Domain** → Buy and add to Cloudflare *(only if using external access)*
+4. **Get API Token** → From Cloudflare dashboard *(only if using external access)*
 5. **Prepare Storage** → Create directories or mount external drive
 6. **Run Setup** → `./scripts/env-manager.sh init`
 7. **Deploy Stack** → `./deploy.sh deploy`
-8. **Configure DNS** → Add A records in Cloudflare
-9. **Port Forward** → Router: ports 80 and 443 to your PC
+8. **Configure DNS** → Add A records in Cloudflare *(only for external access)*
+9. **Port Forward** → Router: ports 80 and 443 to your PC *(only for external access)*
 10. **Configure Prowlarr** → Add indexers FIRST
 11. **Configure Others** → Sonarr, Radarr, qBittorrent
 12. **Add API Keys** → `./scripts/env-manager.sh setup-api-keys`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This stack includes many services, but here are some of the stars of the show:
 *   **Sufficient Disk Space:** Your media library can grow large! Plan accordingly.
 *   **Operating System:** Linux-based OS recommended (scripts are Bash).
 *   **(Optional but Recommended)** Basic familiarity with the command line.
-*   **(For Remote Access)** A domain name you own and a Cloudflare account (for SSL and DNS management).
+*   **(For Remote Access)** A domain name you own and a Cloudflare account (for SSL and DNS management). Skip if you choose local-only access.
 
 ## Getting Started
 

--- a/SETUP_CHECKLIST.md
+++ b/SETUP_CHECKLIST.md
@@ -21,18 +21,18 @@ _Last updated: July 2025_
   - [ ] Drive formatted (NTFS/ext4/APFS)
 
 - [ ] **Network Access**
-  - [ ] Router admin access (for port forwarding)
+  - [ ] Router admin access (for port forwarding, only if using external access)
   - [ ] Know your router IP (usually `192.168.1.1`)
   - [ ] Internet connection working
   - [ ] Decide: Local only or Cloudflare remote access
 
 ### Accounts & Services
-- [ ] **Domain Name Purchased**
+- [ ] **Domain Name Purchased** *(only for external access)*
   - [ ] From Namecheap, Cloudflare, or other registrar
   - [ ] Example: `media-yourname.com`
   - [ ] Cost: ~$10-15/year
 
-- [ ] **Cloudflare Account Created**
+- [ ] **Cloudflare Account Created** *(only for external access)*
   - [ ] Free account at [cloudflare.com](https://cloudflare.com)
   - [ ] Domain added to Cloudflare
   - [ ] Nameservers changed (may take 24 hours)
@@ -147,8 +147,8 @@ _Last updated: July 2025_
   - [ ] **Domain**: Enter your domain (e.g., `media.yourname.com`)
   - [ ] **Timezone**: Your timezone (e.g., `America/New_York`)
   - [ ] **User IDs**: Accept auto-detected values
-  - [ ] **Cloudflare Email**: Your Cloudflare account email
-  - [ ] **API Token**: Paste your Cloudflare API token
+  - [ ] **Cloudflare Email**: Your Cloudflare account email *(external access only)*
+  - [ ] **API Token**: Paste your Cloudflare API token *(external access only)*
 
 ### Customize Paths (If Using External Drive)
 - [ ] **Edit Configuration**: `nano .env`

--- a/interactive-setup.sh
+++ b/interactive-setup.sh
@@ -431,8 +431,7 @@ step_welcome() {
     echo
     echo -e "${COLORS[YELLOW]}${SYMBOLS[INFO]} ${COLORS[BOLD]}What you'll need:${COLORS[RESET]}"
     echo -e "  ${SYMBOLS[BULLET]} A computer with Docker installed"
-    echo -e "  ${SYMBOLS[BULLET]} A domain name (\$10-15/year)"
-    echo -e "  ${SYMBOLS[BULLET]} Cloudflare account (free)"
+    echo -e "  ${SYMBOLS[BULLET]} A domain name (\$10-15/year) and Cloudflare account (free) if you want external access"
     echo -e "  ${SYMBOLS[BULLET]} 30-60 minutes of your time"
     echo
     echo -e "${COLORS[GREEN]}${SYMBOLS[TROPHY]} ${COLORS[BOLD]}Result: Save \$1,500+/year vs Netflix, Hulu, Disney+!${COLORS[RESET]}"
@@ -451,10 +450,10 @@ step_access_mode() {
     CURRENT_STEP=2
     show_progress $CURRENT_STEP $TOTAL_STEPS
 
-    section_header "Access Mode" "Choose local-only or Cloudflare remote access" "${SYMBOLS[GLOBE]}"
-    echo -e "${COLORS[CYAN]}You can run the stack only on your local network or expose it securely via Cloudflare.${COLORS[RESET]}"
+    section_header "Access Mode" "Choose local-only or Cloudflare external access" "${SYMBOLS[GLOBE]}"
+    echo -e "${COLORS[CYAN]}You can run the stack only on your local network or expose it securely via Cloudflare for remote access.${COLORS[RESET]}"
     echo
-    if prompt_yn "Enable remote access using Cloudflare?" "y"; then
+    if prompt_yn "Enable external access using Cloudflare?" "y"; then
         ACCESS_MODE="cloudflare"
     else
         ACCESS_MODE="local"


### PR DESCRIPTION
## Summary
- clarify domain & Cloudflare are optional for external access
- tweak interactive setup wording for external access
- mark optional steps throughout documentation
- clean up accidental file

## Testing
- `shellcheck interactive-setup.sh`
- `bash -n interactive-setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_687070c32850832eb167a5474d1240ce