### PR TITLE
Improve logging and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The interactive setup or your environment configuration files (`.env` or similar
 - **Permission Issues:** Double-check directory permissions set by `setup.sh`.
 - **Port Conflicts:** Ensure the ports required by the services are not already in use.
 - **Docker Logs:** Use `docker logs <container_name>` to check for errors in specific services.
+- **Setup Logs:** `deploy.sh` writes a `deploy.log` file in the project root.
+  Check this log if the deployment exits unexpectedly.
 
 ## Contributing
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,10 +3,19 @@
 # Media Stack Deployment Script
 # Intelligent deployment with environment validation and GPU detection
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR"
+
+LOG_FILE="$PROJECT_ROOT/deploy.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+error_exit() {
+    echo -e "${RED}[ERROR]${NC} Command failed at line $1"
+}
+
+trap 'error_exit $LINENO' ERR
 
 # Colors for output
 RED='\033[0;31m'

--- a/interactive-setup.sh
+++ b/interactive-setup.sh
@@ -31,7 +31,7 @@ elif command -v whiptail >/dev/null 2>&1; then
 fi
 BACKTITLE="Media Stack Setup Wizard"
 
-set -e
+set -euo pipefail
 
 # ============================================================================
 # CONFIGURATION AND GLOBALS
@@ -41,6 +41,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR"
 SETUP_LOG="$PROJECT_ROOT/setup.log"
 PROGRESS_FILE="$PROJECT_ROOT/.setup_progress"
+
+LOG_FILE="$SETUP_LOG"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+error_exit() {
+  echo "Error on line $1" >&2
+}
+
+trap 'error_exit $LINENO' ERR
 
 # Colors and formatting
 declare -A COLORS=(

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,16 @@
 # Media Stack Setup Script
 # This script creates necessary directories and sets proper permissions
 
-set -e
+set -euo pipefail
+
+LOG_FILE="setup.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+error_exit() {
+    echo -e "${RED}[ERROR]${RESET} Line $1 failed"
+}
+
+trap 'error_exit $LINENO' ERR
 
 # Colors and symbols for interactive output
 RED='\033[0;31m'

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,16 @@
 
 # Quick start script for Media Stack
 
-set -e
+set -euo pipefail
+
+LOG_FILE="start.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+error_exit() {
+    echo "❌ Command failed at line $1"
+}
+
+trap 'error_exit $LINENO' ERR
 
 echo "🚀 Starting Media Stack..."
 


### PR DESCRIPTION
## Summary
- add deployment log tip to README
- log script execution to files and show failing lines in error handler

## Testing
- `bash -n start.sh deploy.sh setup.sh interactive-setup.sh scripts/env-manager.sh`
- `shellcheck start.sh deploy.sh setup.sh interactive-setup.sh scripts/env-manager.sh`

------
https://chatgpt.com/codex/tasks/task_e_68719090b608832eb65fee50ba5bdb0d