### PR TITLE
Improve progress resume in setup wizard

### DIFF
--- a/interactive-setup.sh
+++ b/interactive-setup.sh
@@ -106,15 +106,21 @@ log() {
 
 # Save progress
 save_progress() {
-    echo "$CURRENT_STEP" > "$PROGRESS_FILE"
+    echo "${CURRENT_STEP}:${TOTAL_STEPS}" > "$PROGRESS_FILE"
     log "Progress saved: Step $CURRENT_STEP/$TOTAL_STEPS"
 }
 
 # Load progress
 load_progress() {
     if [ -f "$PROGRESS_FILE" ]; then
-        CURRENT_STEP=$(cat "$PROGRESS_FILE")
-        log "Progress loaded: Step $CURRENT_STEP/$TOTAL_STEPS"
+        IFS=":" read -r saved_step saved_total < "$PROGRESS_FILE"
+        if [ -n "$saved_total" ] && [ "$saved_total" -ne "$TOTAL_STEPS" ]; then
+            log "Progress file outdated (saved $saved_total steps, expected $TOTAL_STEPS). Starting fresh."
+            CURRENT_STEP=0
+        else
+            CURRENT_STEP="$saved_step"
+            log "Progress loaded: Step $CURRENT_STEP/$TOTAL_STEPS"
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary
- preserve total step count when saving progress
- detect outdated `.setup_progress` files and start fresh if step count changed

## Testing
- `bash -n interactive-setup.sh`
- `shellcheck interactive-setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6871c899e1f8832e98b3359d3143a29c