### PR TITLE
Align local deployment handling with access mode settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ docker compose logs -f [service] # Follow service logs
 - GPU acceleration auto-detection (NVIDIA, Intel, AMD)
 - Hardware-specific Docker Compose generation
 - Optional Cloudflare SSL integration for secure remote access
-- Local-only mode available (set `LOCAL_ONLY=true`)
+- Local-only mode available (set `ACCESS_MODE=local`)
 
 ### Key Files
 - `docker-compose.yml`: Main service definitions (generated)

--- a/deploy.sh
+++ b/deploy.sh
@@ -69,12 +69,21 @@ check_environment() {
     set -a
     source "$PROJECT_ROOT/.env"
     set +a
-    
-    # Check for basic configuration (skip Cloudflare check if LOCAL_ONLY=true)
-    if [[ "$LOCAL_ONLY" != "true" ]]; then
+
+    # Normalize access mode while preserving backward compatibility
+    ACCESS_MODE=${ACCESS_MODE:-remote}
+    LOCAL_MODE=${LOCAL_MODE:-false}
+    if [[ "$LOCAL_MODE" != "true" ]]; then
+        if [[ "${LOCAL_ONLY:-}" == "true" || "$ACCESS_MODE" == "local" ]]; then
+            LOCAL_MODE=true
+        fi
+    fi
+
+    # Check for basic configuration (skip Cloudflare check in local mode)
+    if [[ "$LOCAL_MODE" != "true" ]]; then
         if [[ "$DOMAIN" == *"yourdomain"* ]] || [[ "$CLOUDFLARE_API_TOKEN" == *"your-"* ]]; then
             error "Environment not properly configured for remote access"
-            info "Run: ./scripts/env-manager.sh init or set LOCAL_ONLY=true for local access"
+            info "Run: ./scripts/env-manager.sh init or set ACCESS_MODE=local for local access"
             exit 1
         fi
     fi
@@ -186,7 +195,7 @@ generate_compose_file() {
     cp "$source_file" "$output_file.tmp"
     
     # Handle local-only mode (use local template instead)
-    if [[ "$LOCAL_ONLY" == "true" ]]; then
+    if [[ "$LOCAL_MODE" == "true" ]]; then
         log "Configuring for local-only access (no SSL)"
         # Use local-only template
         source_file="$PROJECT_ROOT/docker-compose.local.yml"
@@ -401,14 +410,13 @@ main() {
             ./scripts/env-manager.sh init
             ;;
         "deploy")
-            check_environment
-            
             # Parse additional arguments
             shift || true
             while [[ $# -gt 0 ]]; do
                 case $1 in
                     --local)
-                        export LOCAL_ONLY=true
+                        LOCAL_MODE=true
+                        ACCESS_MODE=local
                         log "Enabling local-only mode"
                         ;;
                     --with-auto-update)
@@ -428,6 +436,8 @@ main() {
                 esac
                 shift
             done
+
+            check_environment
             
             # Detect GPU capabilities
             local detected_gpu="${gpu_override:-$(detect_gpu)}"

--- a/start.sh
+++ b/start.sh
@@ -48,11 +48,20 @@ echo ""
 echo "✅ Media Stack started successfully!"
 echo ""
 # Show appropriate URLs based on deployment mode
-DOMAIN=$(grep DOMAIN= .env | cut -d= -f2)
-LOCAL_ONLY=$(grep LOCAL_ONLY= .env | cut -d= -f2 2>/dev/null)
+DOMAIN=$(grep -E '^DOMAIN=' .env | head -n1 | cut -d= -f2- || true)
+ACCESS_MODE=$(grep -E '^ACCESS_MODE=' .env | head -n1 | cut -d= -f2- || true)
+
+if [[ -z "$DOMAIN" ]]; then
+    DOMAIN="localhost"
+fi
+
+LOCAL_MODE=false
+if [[ "$ACCESS_MODE" == "local" || "$DOMAIN" == "localhost" ]]; then
+    LOCAL_MODE=true
+fi
 
 echo "🌐 Access your services at:"
-if [[ "$LOCAL_ONLY" == "true" || "$DOMAIN" == "localhost" ]]; then
+if [[ "$LOCAL_MODE" == "true" ]]; then
     echo "   Jellyfin:     http://localhost:8096"
     echo "   Dashboard:    http://localhost:7575"
     echo "   Overseerr:    http://localhost:5055"


### PR DESCRIPTION
## Summary
- normalize deploy.sh environment checks to derive local mode from ACCESS_MODE or backwards-compatible LOCAL_ONLY values and honor the --local flag before validation
- adjust compose generation to use the computed local mode flag and avoid unnecessary Cloudflare requirements for local deployments
- update start.sh URL output logic and CLAUDE.md documentation to reflect ACCESS_MODE=local usage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292db2ffa0832e81f5904dde87e599)